### PR TITLE
Uses Daffodil version 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,24 @@ the dfdl:inputValueCalc, dfdl:outputValueCalc,
 dfdl:hiddenGroupRef, dfdl:valueLength(), dfdl:contentLength(),
 and dfdl:newVariableInstance DFDL capabilities.
 
-As of version 1.1.0 of this DFDL schema, it also uses a Daffodil-specific DFDL extension called layers in order
-to compute IPv4 checksums as part of parsing and unparsing. 
-
 This schema was created based on the corresponding DFDL types in the PCAP schema, which has been refactored
 to use this schema as a dependency.
 
 This division into two schemas is intended to illustrate how to structure DFDL schemas as separate DFDL 
 schemas that are combined together to form a complete format, and which involve layering where a 
-container/envelope/header structure, contains a payload structure. PCAP is an container format for Ethernet/IP packets. 
+container/envelope/header structure, contains a payload structure. 
+PCAP is a container format for Ethernet/IP packets. 
 
+## Release Notes
+
+### 1.2.0
+Updated for Daffodil version 3.4.0
+
+This schema is used as a component schema by the PCAP DFDL schema. 
+Hence, a Daffodil 3.4.0 version of this schema is needed.
+
+### 1.1.0
+As of version 1.1.0 of this DFDL schema, it also uses a Daffodil-specific DFDL extension called layers in order
+  to compute IPv4 checksums as part of parsing and unparsing.
+
+Works with Daffoddil 3.2.1 

--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,10 @@ version := "1.2.0"
 scalaVersion := "2.12.18"
  
 libraryDependencies ++= Seq(
-  "org.apache.daffodil" %% "daffodil-lib" % "3.5.0",
-  "org.apache.daffodil" %% "daffodil-runtime1" % "3.5.0",
-  "org.apache.daffodil" %% "daffodil-runtime1-layers" % "3.5.0",
-  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.5.0" % "test",
+  "org.apache.daffodil" %% "daffodil-lib" % "3.4.0",
+  "org.apache.daffodil" %% "daffodil-runtime1" % "3.4.0",
+  "org.apache.daffodil" %% "daffodil-runtime1-layers" % "3.4.0",
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.4.0" % "test",
   "junit" % "junit" % "4.13.2" % "test",
   "com.github.sbt" % "junit-interface" % "0.13.2" % "test"
 )


### PR DESCRIPTION
Plan is to tag this as 1.2.0 and have it be on branch v1.2.0, but be the official version for use with Daffodil 3.4.0
