### PR TITLE
Update version to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ PCAP is a container format for Ethernet/IP packets.
 
 ## Release Notes
 
+### 1.3.0
+Updated for Daffodil version 3.5.0
+
 ### 1.2.0
 Updated for Daffodil version 3.4.0
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,17 +2,17 @@ name := "dfdl-ethernetIP"
 
 organization := "com.owlcyberdefense"
 
-version := "1.2.0"
+version := "1.3.0"
 
 scalaVersion := "2.12.18"
  
 libraryDependencies ++= Seq(
-  "org.apache.daffodil" %% "daffodil-lib" % "3.4.0",
-  "org.apache.daffodil" %% "daffodil-runtime1" % "3.4.0",
-  "org.apache.daffodil" %% "daffodil-runtime1-layers" % "3.4.0",
-  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.4.0" % "test",
+  "org.apache.daffodil" %% "daffodil-lib" % "3.5.0",
+  "org.apache.daffodil" %% "daffodil-runtime1" % "3.5.0",
+  "org.apache.daffodil" %% "daffodil-runtime1-layers" % "3.5.0",
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.5.0" % "test",
   "junit" % "junit" % "4.13.2" % "test",
-  "com.github.sbt" % "junit-interface" % "0.13.2" % "test"
+  "com.github.sbt" % "junit-interface" % "0.13.3" % "test"
 )
 
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=1.9.0
+sbt.version=1.9.3
+


### PR DESCRIPTION
Intended to be tagged as 1.3.0 for use with Daffodil 3.5.0

Because we need separate versions for daffodil 3.5.0 and 3.4.0

Updated junit-interface to latest version.
Updated sbt to latest version.