### PR TITLE
Update to use Daffodil 4.0.0 by default and improve schema coding style

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ container/envelope/header structure, contains a payload structure. PCAP is an co
 
 ## Release Notes
 
+### 1.4.1
+Updated for Daffodil version 4.0.0
+
 ### 1.4.0
 Updated for Daffodil version 3.8.0
 Uses Daffodil new layer API for IPv4 checksum

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ container/envelope/header structure, contains a payload structure. PCAP is an co
 
 ## Release Notes
 
+### 1.4.2
+
+Conforms to current (2025-10-17) DFDL schema style guidance. 
+Many people use this DFDL schema as part of learning about DFDL, so it 
+needed to be updated to reflect known best practices.
+
 ### 1.4.1
 Updated for Daffodil version 4.0.0
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ name := "dfdl-ethernetIP"
 
 organization := "com.owlcyberdefense"
 
-version := "1.4.0"
+version := "1.4.1"
 
-daffodilVersion := "3.8.0"
+daffodilVersion := "4.0.0"
 
 enablePlugins(DaffodilPlugin)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "dfdl-ethernetIP"
 
 organization := "com.owlcyberdefense"
 
-version := "1.4.1"
+version := "1.4.2"
 
 daffodilVersion := "4.0.0"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.11.6

--- a/src/main/resources/com/owlcyberdefense/dfdl/xsd/IPv4ChecksumLayer.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/dfdl/xsd/IPv4ChecksumLayer.dfdl.xsd
@@ -15,16 +15,17 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-           xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
-           xmlns:fn="http://www.w3.org/2005/xpath-functions"
-           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-           xmlns:ipv4="urn:com.owlcyberdefense.dfdl.IPv4Checksum"
-           targetNamespace="urn:com.owlcyberdefense.dfdl.IPv4Checksum">
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+        xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+        xmlns:fn="http://www.w3.org/2005/xpath-functions"
+        xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+        xmlns:ipv4="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4"
+        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4">
 
-  <xs:annotation>
-    <xs:documentation>
+  <annotation>
+    <documentation>
       Variable for the layer transform used for IPv4 checksum calculation.
 
       Per the checksum algorithm described in IETF RFC791.
@@ -32,18 +33,18 @@
       If the data doesn't match this expected fixed length, issue PE/UE.
 
       This checksum is written into the result variable.
-    </xs:documentation>
-    <xs:appinfo source="http://www.ogf.org/dfdl/">
+    </documentation>
+    <appinfo source="http://www.ogf.org/dfdl/">
       <dfdl:defineVariable name="IPv4Checksum" type="xs:unsignedShort"/>
       <dfdl:defineFormat name="IPv4ChecksumLayer">
         <dfdl:format dfdlx:layer='ipv4:IPv4Checksum' />
       </dfdl:defineFormat>
-    </xs:appinfo>
-  </xs:annotation>
+    </appinfo>
+  </annotation>
 
-  <xs:simpleType name="IPv4Checksum"
+  <simpleType name="IPv4Checksum"
     dfdl:lengthKind="explicit" dfdl:length="16" dfdl:lengthUnits="bits">
-    <xs:restriction base="xs:unsignedShort"/>
-  </xs:simpleType>
+    <restriction base="xs:unsignedShort"/>
+  </simpleType>
 
-</xs:schema>
+</schema>

--- a/src/main/resources/com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd
@@ -41,21 +41,21 @@ conventions useful for describing things like IP packets.
 -->
 
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-           xmlns:fn="http://www.w3.org/2005/xpath-functions"
-           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-           xmlns:b="urn:basicBinary"
-           xmlns:tns="urn:basicBinary"
-           targetNamespace="urn:basicBinary">
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+        xmlns:fn="http://www.w3.org/2005/xpath-functions"
+        xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+        xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
+        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb">
 
-  <xs:include schemaLocation="org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
+  <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
 
-  <xs:annotation>
-    <xs:appinfo source="http://www.ogf.org/dfdl/">
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
 
       <dfdl:defineFormat name="basicByteBinary">
-        <dfdl:format ref="tns:GeneralFormat"
+        <dfdl:format ref="bb:GeneralFormat"
                      alignment="1"
                      alignmentUnits="bits"
                      binaryBooleanFalseRep="0"
@@ -69,31 +69,31 @@ conventions useful for describing things like IP packets.
                    />
       </dfdl:defineFormat>
 
-      <dfdl:format ref="b:basicByteBinary"/>
+      <dfdl:format ref="bb:basicByteBinary"/>
 
-    </xs:appinfo>
-  </xs:annotation>
+    </appinfo>
+  </annotation>
 
-  <xs:simpleType name="bit"
+  <simpleType name="bit"
                  dfdl:lengthKind="explicit"
                  dfdl:lengthUnits="bits">
-    <xs:restriction base="xs:unsignedInt" />
-  </xs:simpleType>
+    <restriction base="xs:unsignedInt" />
+  </simpleType>
 
-  <xs:simpleType name="hexByte" dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes">
-    <xs:restriction base="xs:hexBinary" />
-  </xs:simpleType>
+  <simpleType name="hexByte" dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes">
+    <restriction base="xs:hexBinary" />
+  </simpleType>
 
-  <xs:simpleType name="uint16" dfdl:lengthKind="explicit" dfdl:length="16">
-    <xs:restriction base="xs:unsignedInt"/>
-  </xs:simpleType>
+  <simpleType name="uint16" dfdl:lengthKind="explicit" dfdl:length="16">
+    <restriction base="xs:unsignedInt"/>
+  </simpleType>
 
-  <xs:simpleType name="uint32" dfdl:lengthKind="explicit" dfdl:length="32">
-    <xs:restriction base="xs:unsignedInt"/>
-  </xs:simpleType>
+  <simpleType name="uint32" dfdl:lengthKind="explicit" dfdl:length="32">
+    <restriction base="xs:unsignedInt"/>
+  </simpleType>
 
-  <xs:simpleType name="int32" dfdl:lengthKind="explicit" dfdl:length="4" dfdl:lengthUnits="bytes">
-    <xs:restriction base="xs:int"/>
-  </xs:simpleType>
+  <simpleType name="int32" dfdl:lengthKind="explicit" dfdl:length="4" dfdl:lengthUnits="bytes">
+    <restriction base="xs:int"/>
+  </simpleType>
 
-</xs:schema>
+</schema>

--- a/src/main/resources/com/owlcyberdefense/dfdl/xsd/ethernetIP.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/dfdl/xsd/ethernetIP.dfdl.xsd
@@ -33,29 +33,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
 SOFTWARE.
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-           xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
-           xmlns:fn="http://www.w3.org/2005/xpath-functions"
-           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-           xmlns:chksum="urn:com.owlcyberdefense.dfdl.IPv4Checksum"
-           xmlns:b="urn:basicBinary"
-           xmlns:ip="urn:ipAddress"
-           xmlns:eth="urn:ethernet"
-           xmlns:tns="urn:ethernet"
-           targetNamespace="urn:ethernet">
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+        xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+        xmlns:fn="http://www.w3.org/2005/xpath-functions"
+        xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+        xmlns:chksum="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4"
+        xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
+        xmlns:ipa="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa"
+        xmlns:eth="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
+        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth">
 
-  <xs:import namespace="urn:basicBinary" schemaLocation="basicByteBinary.dfdl.xsd"/>
-  <xs:import namespace="urn:ipAddress" schemaLocation="ipAddress.dfdl.xsd"/>
-  <xs:import namespace="urn:com.owlcyberdefense.dfdl.IPv4Checksum"
+  <import namespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb" schemaLocation="basicByteBinary.dfdl.xsd"/>
+  <import namespace="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa" schemaLocation="ipAddress.dfdl.xsd"/>
+  <import namespace="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4"
              schemaLocation="IPv4ChecksumLayer.dfdl.xsd"/>
-  <xs:annotation>
-    <xs:appinfo source="http://www.ogf.org/dfdl/">
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
 
-      <dfdl:format ref="b:basicByteBinary"/>
+      <dfdl:format ref="bb:basicByteBinary"/>
 
-    </xs:appinfo>
-  </xs:annotation>
+    </appinfo>
+  </annotation>
 
   <!--
   This schema does not define any global elements.
@@ -63,38 +63,38 @@ SOFTWARE.
   This is because ethernet data is always contained in some other medium such as a PCAP file.
   -->
 
-  <xs:complexType name="Ethernet">
-    <xs:sequence>
-      <xs:element name="MACDest" type="b:hexByte" dfdl:length="6"/>
-      <xs:element name="MACSrc" type="b:hexByte" dfdl:length="6"/>
-      <xs:element name="Ethertype" type="b:bit" dfdl:length="16"
+  <complexType name="Ethernet">
+    <sequence>
+      <element name="MACDest" type="bb:hexByte" dfdl:length="6"/>
+      <element name="MACSrc" type="bb:hexByte" dfdl:length="6"/>
+      <element name="Ethertype" type="bb:bit" dfdl:length="16"
                   dfdl:outputValueCalc="{
           if (fn:exists(../NetworkLayer/IPv4)) then 2048
           else if (fn:exists(../NetworkLayer/IPv6 )) then 34525
           else fn:error('ethernet', 'fn:error called.', .) }"/>
-      <xs:element name="NetworkLayer" type="tns:NetworkLayer"/>
-    </xs:sequence>
-  </xs:complexType>
+      <element name="NetworkLayer" type="eth:NetworkLayer"/>
+    </sequence>
+  </complexType>
 
   <!-- NETWORK LAYER -->
 
-  <xs:complexType name="NetworkLayer">
-    <xs:choice dfdl:choiceDispatchKey="{ xs:string(../Ethertype) }">
-      <xs:element dfdl:choiceBranchKey="2048" name="IPv4" type="tns:IPv4"/>
-      <xs:element dfdl:choiceBranchKey="34525" name="IPv6" type="tns:IPv6"/>
-    </xs:choice>
-  </xs:complexType>
+  <complexType name="NetworkLayer">
+    <choice dfdl:choiceDispatchKey="{ xs:string(../Ethertype) }">
+      <element dfdl:choiceBranchKey="2048" name="IPv4" type="eth:IPv4"/>
+      <element dfdl:choiceBranchKey="34525" name="IPv6" type="eth:IPv6"/>
+    </choice>
+  </complexType>
 
-  <xs:complexType name="IPv4">
-    <xs:sequence>
-      <xs:element name="IPv4Header">
-        <xs:complexType>
+  <complexType name="IPv4">
+    <sequence>
+      <element name="IPv4Header">
+        <complexType>
           <!--
           Modified with proposed checksum computation via layer transform
           -->
-          <xs:sequence>
-            <xs:annotation>
-              <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <sequence>
+            <annotation>
+              <appinfo source="http://www.ogf.org/dfdl/">
                 <!--
                 The checksum field in an IPv4 actually lives in the middle of the
                 data that it is a checksum of.
@@ -116,16 +116,16 @@ SOFTWARE.
                 the ComputedChecksum variable.
                 -->
                 <dfdl:newVariableInstance ref="chksum:IPv4Checksum"/>
-              </xs:appinfo>
-            </xs:annotation>
+              </appinfo>
+            </annotation>
 
-            <xs:sequence dfdl:ref="chksum:IPv4ChecksumLayer">
-              <xs:sequence>
-                <xs:element name="Version" type="b:bit" dfdl:length="4"/>
-                <xs:element name="IHL" type="b:bit" dfdl:length="4"/>
-                <xs:element name="DSCP" type="b:bit" dfdl:length="6"/>
-                <xs:element name="ECN" type="b:bit" dfdl:length="2"/>
-                <xs:element name="Length" type="b:bit" dfdl:length="16"
+            <sequence dfdl:ref="chksum:IPv4ChecksumLayer">
+              <sequence>
+                <element name="Version" type="bb:bit" dfdl:length="4"/>
+                <element name="IHL" type="bb:bit" dfdl:length="4"/>
+                <element name="DSCP" type="bb:bit" dfdl:length="6"/>
+                <element name="ECN" type="bb:bit" dfdl:length="2"/>
+                <element name="Length" type="bb:bit" dfdl:length="16"
                             dfdl:outputValueCalc="{
                 if (fn:exists(../../TransportLayer))
                 then
@@ -138,28 +138,28 @@ SOFTWARE.
                      then dfdl:valueLength(../../ICMPv4/EchoRequest/Payload, 'bytes') + 20 + 8
                      else dfdl:valueLength(../../ICMPv4/EchoReply/Payload, 'bytes') + 20 + 8
                 } "/>
-                <xs:element name="Identification" type="b:bit" dfdl:length="16"/>
-                <xs:element name="Flags" type="b:bit" dfdl:length="3"/>
-                <xs:element name="FragmentOffset" type="b:bit" dfdl:length="13"/>
-                <xs:element name="TTL" type="b:bit" dfdl:length="8"/>
-                <xs:element name="Protocol" type="b:bit" dfdl:length="8"
+                <element name="Identification" type="bb:bit" dfdl:length="16"/>
+                <element name="Flags" type="bb:bit" dfdl:length="3"/>
+                <element name="FragmentOffset" type="bb:bit" dfdl:length="13"/>
+                <element name="TTL" type="bb:bit" dfdl:length="8"/>
+                <element name="Protocol" type="bb:bit" dfdl:length="8"
                             dfdl:outputValueCalc="{
                 if (fn:exists(../../ICMPv4)) then 1
                 else if (fn:exists(../../TransportLayer/TCP)) then 6
                 else if (fn:exists(../../TransportLayer/UDP)) then 17
                 else -1 }"/>
-                <xs:element name="Checksum" type="chksum:IPv4Checksum"/>
-                <xs:element name="IPSrc" type="ip:IPAddress"/>
-                <xs:element name="IPDest" type="ip:IPAddress"/>
-              </xs:sequence>
-            </xs:sequence>
+                <element name="Checksum" type="chksum:IPv4Checksum"/>
+                <element name="IPSrc" type="ipa:IPAddress"/>
+                <element name="IPDest" type="ipa:IPAddress"/>
+              </sequence>
+            </sequence>
 
             <!--
             We want the schema author to have all options on what to do if the
             checksum is incorrect when parsing. Hence, we just put the computed value
             into this element.
             -->
-            <xs:element name="ComputedChecksum" type="chksum:IPv4Checksum"
+            <element name="ComputedChecksum" type="chksum:IPv4Checksum"
                         dfdl:inputValueCalc='{ $chksum:IPv4Checksum }'/>
             <!--
             One recommendation is to treat incorrect checksum values as a validation
@@ -174,78 +174,78 @@ SOFTWARE.
             A schematron check would accomplish much the same thing, with the
             advantage that the error would be reported as an "official" validation error.
             -->
-            <xs:sequence>
-              <xs:annotation>
-                <xs:appinfo source="http://www.ogf.org/dfdl/">
+            <sequence>
+              <annotation>
+                <appinfo source="http://www.ogf.org/dfdl/">
                   <dfdl:assert
                     failureType="recoverableError"
                     message="Incorrect checksum."
                     test='{ Checksum eq ComputedChecksum }'
                   />
-                </xs:appinfo>
-              </xs:annotation>
-            </xs:sequence>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="Protocol" type="xs:unsignedInt"
+                </appinfo>
+              </annotation>
+            </sequence>
+          </sequence>
+        </complexType>
+      </element>
+      <element name="Protocol" type="xs:unsignedInt"
                   dfdl:inputValueCalc="{ xs:unsignedInt(../IPv4Header/Protocol) }"/>
-      <xs:choice dfdl:choiceDispatchKey="{ xs:string(./Protocol) }">
-        <xs:element dfdl:choiceBranchKey="6 17" name="TransportLayer" type="tns:TransportLayer"
+      <choice dfdl:choiceDispatchKey="{ xs:string(./Protocol) }">
+        <element dfdl:choiceBranchKey="6 17" name="TransportLayer" type="eth:TransportLayer"
                     dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes"
                     dfdl:length="{ xs:unsignedInt(../IPv4Header/Length) - 20 }"/>
-        <xs:element dfdl:choiceBranchKey="1" name="ICMPv4" type="tns:ICMPv4"
+        <element dfdl:choiceBranchKey="1" name="ICMPv4" type="eth:ICMPv4"
                     dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes"
                     dfdl:length="{ xs:unsignedInt(../IPv4Header/Length) - 20 }"/>
-      </xs:choice>
-    </xs:sequence>
-  </xs:complexType>
+      </choice>
+    </sequence>
+  </complexType>
 
-  <xs:complexType name="ICMPv4">
-    <xs:sequence>
-      <xs:element name="Type" type="b:bit" dfdl:length="8"
+  <complexType name="ICMPv4">
+    <sequence>
+      <element name="Type" type="bb:bit" dfdl:length="8"
                   dfdl:outputValueCalc="{
           if (fn:exists(../EchoRequest)) then 8
           else if (fn:exists(../EchoReply )) then 0
           else -1 }"/>
-      <xs:element name="Code" type="b:bit" dfdl:length="8"
+      <element name="Code" type="bb:bit" dfdl:length="8"
                   dfdl:outputValueCalc="{
           if (fn:exists(../EchoRequest)) then 0
           else if (fn:exists(../EchoReply )) then 0
           else -1 }"/>
-      <xs:element name="Checksum" type="b:bit" dfdl:length="16"/>
-      <xs:choice dfdl:choiceDispatchKey="{ fn:concat(xs:string(./Type), '_', xs:string(./Code)) }">
-        <xs:element name="EchoRequest" dfdl:choiceBranchKey="8_0">
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="Identifier" type="b:bit" dfdl:length="16"/>
-              <xs:element name="SequenceNumber" type="b:bit" dfdl:length="16"/>
-              <xs:element name="Payload" type="b:hexByte" dfdl:length="{ (../../../IPv4Header/Length - 20) - 8 }"/>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
-        <xs:element name="EchoReply" dfdl:choiceBranchKey="0_0">
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="Identifier" type="b:bit" dfdl:length="16"/>
-              <xs:element name="SequenceNumber" type="b:bit" dfdl:length="16"/>
-              <xs:element name="Payload" type="b:hexByte" dfdl:length="{ (../../../IPv4Header/Length - 20) - 8 }"/>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
-      </xs:choice>
-    </xs:sequence>
-  </xs:complexType>
+      <element name="Checksum" type="bb:bit" dfdl:length="16"/>
+      <choice dfdl:choiceDispatchKey="{ fn:concat(xs:string(./Type), '_', xs:string(./Code)) }">
+        <element name="EchoRequest" dfdl:choiceBranchKey="8_0">
+          <complexType>
+            <sequence>
+              <element name="Identifier" type="bb:bit" dfdl:length="16"/>
+              <element name="SequenceNumber" type="bb:bit" dfdl:length="16"/>
+              <element name="Payload" type="bb:hexByte" dfdl:length="{ (../../../IPv4Header/Length - 20) - 8 }"/>
+            </sequence>
+          </complexType>
+        </element>
+        <element name="EchoReply" dfdl:choiceBranchKey="0_0">
+          <complexType>
+            <sequence>
+              <element name="Identifier" type="bb:bit" dfdl:length="16"/>
+              <element name="SequenceNumber" type="bb:bit" dfdl:length="16"/>
+              <element name="Payload" type="bb:hexByte" dfdl:length="{ (../../../IPv4Header/Length - 20) - 8 }"/>
+            </sequence>
+          </complexType>
+        </element>
+      </choice>
+    </sequence>
+  </complexType>
 
-  <xs:complexType name="IPv6">
-    <xs:sequence>
-      <xs:element name='IPv6Header'>
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="Version" type="b:bit" dfdl:length="4"/>
-            <xs:element name="TrafficClass" type="b:bit" dfdl:length="8"/>
-            <xs:element name="FlowLabel" type="b:bit" dfdl:length="20"/>
-            <xs:element name="PayloadLength" type="b:bit" dfdl:length="16"
+  <complexType name="IPv6">
+    <sequence>
+      <element name='IPv6Header'>
+        <complexType>
+          <sequence>
+            <element name="Version" type="bb:bit" dfdl:length="4"/>
+            <element name="TrafficClass" type="bb:bit" dfdl:length="8"/>
+            <element name="FlowLabel" type="bb:bit" dfdl:length="20"/>
+            <element name="PayloadLength" type="bb:bit" dfdl:length="16"
                         dfdl:outputValueCalc="{
                   if (fn:exists(../../TransportLayer/UDP))
                     then dfdl:valueLength(../../TransportLayer/UDP/Data, 'bytes') + 8
@@ -253,87 +253,87 @@ SOFTWARE.
                          dfdl:valueLength(../../TransportLayer/TCP/TCPHeader/Options, 'bytes') + 20
                 } "/>
             <!-- TODO: Add support for extension headers -->
-            <xs:element name="NextHeader" type="b:bit" dfdl:length="8"
+            <element name="NextHeader" type="bb:bit" dfdl:length="8"
                         dfdl:outputValueCalc="{
                   if (fn:exists(../../TransportLayer/TCP )) then 6
                   else if (fn:exists(../../TransportLayer/UDP )) then 17
                   else -1 }"/>
-            <xs:element name="HopLimit" type="b:bit" dfdl:length="8"/>
-            <xs:element name="IPSrc">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="value" type="b:hexByte" dfdl:length="16"/>
-                </xs:sequence>
-              </xs:complexType>
-            </xs:element>
-            <xs:element name="IPDest">
-              <xs:complexType>
-                <xs:sequence>
-                  <xs:element name="value" type="b:hexByte" dfdl:length="16"/>
-                </xs:sequence>
-              </xs:complexType>
-            </xs:element>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="Protocol" type="xs:unsignedInt"
+            <element name="HopLimit" type="bb:bit" dfdl:length="8"/>
+            <element name="IPSrc">
+              <complexType>
+                <sequence>
+                  <element name="value" type="bb:hexByte" dfdl:length="16"/>
+                </sequence>
+              </complexType>
+            </element>
+            <element name="IPDest">
+              <complexType>
+                <sequence>
+                  <element name="value" type="bb:hexByte" dfdl:length="16"/>
+                </sequence>
+              </complexType>
+            </element>
+          </sequence>
+        </complexType>
+      </element>
+      <element name="Protocol" type="xs:unsignedInt"
                   dfdl:inputValueCalc="{ xs:unsignedInt(../IPv6Header/NextHeader) }"/>
-      <xs:element name="TransportLayer" type="tns:TransportLayer" dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes"
+      <element name="TransportLayer" type="eth:TransportLayer" dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes"
                   dfdl:length="{ xs:unsignedInt(../IPv6Header/PayloadLength) }"/>
-    </xs:sequence>
-  </xs:complexType>
+    </sequence>
+  </complexType>
 
   <!-- TRANSPORT LAYER -->
 
-  <xs:complexType name="TransportLayer">
-    <xs:choice dfdl:choiceDispatchKey="{ xs:string(../Protocol) }">
-      <xs:element name="TCP" type="tns:TCP" dfdl:choiceBranchKey="6"/>
-      <xs:element name="UDP" type="tns:UDP" dfdl:choiceBranchKey="17"/>
-    </xs:choice>
-  </xs:complexType>
+  <complexType name="TransportLayer">
+    <choice dfdl:choiceDispatchKey="{ xs:string(../Protocol) }">
+      <element name="TCP" type="eth:TCP" dfdl:choiceBranchKey="6"/>
+      <element name="UDP" type="eth:UDP" dfdl:choiceBranchKey="17"/>
+    </choice>
+  </complexType>
 
-  <xs:complexType name="TCP">
-    <xs:sequence>
-      <xs:element name='TCPHeader'>
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="PortSRC" type="b:bit" dfdl:length="16"/>
-            <xs:element name="PortDest" type="b:bit" dfdl:length="16"/>
-            <xs:element name="Seq" type="b:bit" dfdl:length="32"/>
-            <xs:element name="Ack" type="b:bit" dfdl:length="32"/>
-            <xs:element name="DataOffset" type="b:bit" dfdl:length="4"
+  <complexType name="TCP">
+    <sequence>
+      <element name='TCPHeader'>
+        <complexType>
+          <sequence>
+            <element name="PortSRC" type="bb:bit" dfdl:length="16"/>
+            <element name="PortDest" type="bb:bit" dfdl:length="16"/>
+            <element name="Seq" type="bb:bit" dfdl:length="32"/>
+            <element name="Ack" type="bb:bit" dfdl:length="32"/>
+            <element name="DataOffset" type="bb:bit" dfdl:length="4"
                         dfdl:outputValueCalc="{ xs:unsignedInt((dfdl:valueLength(../Options, 'bytes') div 4) + 5) }"/>
-            <xs:element name="Reserved" type="b:bit" dfdl:length="3"/>
-            <xs:element name="Flags" type="b:bit" dfdl:length="9"/>
-            <xs:element name="WindowSize" type="b:bit" dfdl:length="16"/>
-            <xs:element name="Checksum" type="b:bit" dfdl:length="16"/>
-            <xs:element name="Urgent" type="b:bit" dfdl:length="16"/>
-            <xs:element name="Options" type="b:hexByte" dfdl:length="{ (xs:unsignedInt(../DataOffset) - 5) * 4 }"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="Data" type="b:hexByte" dfdl:length="{
+            <element name="Reserved" type="bb:bit" dfdl:length="3"/>
+            <element name="Flags" type="bb:bit" dfdl:length="9"/>
+            <element name="WindowSize" type="bb:bit" dfdl:length="16"/>
+            <element name="Checksum" type="bb:bit" dfdl:length="16"/>
+            <element name="Urgent" type="bb:bit" dfdl:length="16"/>
+            <element name="Options" type="bb:hexByte" dfdl:length="{ (xs:unsignedInt(../DataOffset) - 5) * 4 }"/>
+          </sequence>
+        </complexType>
+      </element>
+      <element name="Data" type="bb:hexByte" dfdl:length="{
           if (fn:exists(../../../../IPv4))
           then ((xs:unsignedInt(../../../../IPv4/IPv4Header/Length) - 20) - (xs:unsignedInt(../TCPHeader/DataOffset) * 4))
           else (xs:unsignedInt(../../../../IPv6/IPv6Header/PayloadLength) - (xs:unsignedInt(../TCPHeader/DataOffset) * 4)) }"/>
-    </xs:sequence>
-  </xs:complexType>
+    </sequence>
+  </complexType>
 
-  <xs:complexType name="UDP">
-    <xs:sequence>
-      <xs:element name='UDPHeader'>
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="PortSrc" type="b:bit" dfdl:length="16"/>
-            <xs:element name="PortDest" type="b:bit" dfdl:length="16"/>
-            <xs:element name="Length" type="b:bit" dfdl:length="16"
+  <complexType name="UDP">
+    <sequence>
+      <element name='UDPHeader'>
+        <complexType>
+          <sequence>
+            <element name="PortSrc" type="bb:bit" dfdl:length="16"/>
+            <element name="PortDest" type="bb:bit" dfdl:length="16"/>
+            <element name="Length" type="bb:bit" dfdl:length="16"
                         dfdl:outputValueCalc="{ dfdl:valueLength(../../Data, 'bytes') + 8 }"/>
-            <xs:element name="Checksum" type="b:bit" dfdl:length="16"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
-      <xs:element name="Data" type="b:hexByte" dfdl:length="{ xs:unsignedInt(../UDPHeader/Length) - 8 }"/>
-    </xs:sequence>
-  </xs:complexType>
+            <element name="Checksum" type="bb:bit" dfdl:length="16"/>
+          </sequence>
+        </complexType>
+      </element>
+      <element name="Data" type="bb:hexByte" dfdl:length="{ xs:unsignedInt(../UDPHeader/Length) - 8 }"/>
+    </sequence>
+  </complexType>
 
-</xs:schema>
+</schema>

--- a/src/main/resources/com/owlcyberdefense/dfdl/xsd/ipAddress.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/dfdl/xsd/ipAddress.dfdl.xsd
@@ -33,29 +33,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
 SOFTWARE.
 -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-           xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
-           xmlns:fn="http://www.w3.org/2005/xpath-functions"
-           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-           xmlns:b="urn:basicBinary"
-           xmlns:ip="urn:ipAddress"
-           xmlns:tns="urn:ipAddress"
-           targetNamespace="urn:ipAddress">
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+        xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+        xmlns:fn="http://www.w3.org/2005/xpath-functions"
+        xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+        xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
+        xmlns:ipa="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa"
+        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa">
 
-  <xs:import namespace="urn:basicBinary" schemaLocation="basicByteBinary.dfdl.xsd"/>
+  <import namespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb" schemaLocation="basicByteBinary.dfdl.xsd"/>
 
-  <xs:annotation>
-    <xs:appinfo source="http://www.ogf.org/dfdl/">
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
 
-      <dfdl:format ref="b:basicByteBinary"/>
+      <dfdl:format ref="bb:basicByteBinary"/>
 
-    </xs:appinfo>
-  </xs:annotation>
+    </appinfo>
+  </annotation>
 
-  <xs:complexType name="IPAddress">
-    <xs:annotation>
-      <xs:documentation><![CDATA[
+  <complexType name="IPAddress">
+    <annotation>
+      <documentation><![CDATA[
 
       The underlying representation of this group is four single-byte unsigned binary integers.
 
@@ -86,84 +86,84 @@ SOFTWARE.
       people can use it to deal with IPv4 addresses anywhere. However, it is hard to
       ascertain the correctness and security/safety of this DFDL schema by inspection alone.
 
-      ]]></xs:documentation>
-    </xs:annotation>
-    <xs:sequence>
-      <xs:sequence dfdl:hiddenGroupRef="tns:h_IPAddressGroup"/>
-      <xs:element name="value" type="xs:string"
+      ]]></documentation>
+    </annotation>
+    <sequence>
+      <sequence dfdl:hiddenGroupRef="ipa:h_IPAddressGroup"/>
+      <element name="value" type="xs:string"
                   dfdl:inputValueCalc="{ fn:concat(../Byte1, '.', ../Byte2, '.', ../Byte3, '.', ../Byte4) }"/>
-    </xs:sequence>
-  </xs:complexType>
+    </sequence>
+  </complexType>
 
-  <xs:annotation>
-    <xs:appinfo source="http://www.ogf.org/dfdl/">
+  <annotation>
+    <appinfo source="http://www.ogf.org/dfdl/">
 
       <!-- Internally used by h_IPAddressGroup -->
       <dfdl:defineVariable name="remainingDottedAddr" type="xs:string" dfdlx:direction="unparseOnly"/>
       <dfdl:defineVariable name="priorRemainingDottedAddr" type="xs:string" dfdlx:direction="unparseOnly"/>
 
-    </xs:appinfo>
-  </xs:annotation>
+    </appinfo>
+  </annotation>
 
-  <xs:group name="h_IPAddressGroup">
-    <xs:sequence>
-      <xs:annotation>
-        <xs:appinfo source="http://www.ogf.org/dfdl/">
-          <dfdl:newVariableInstance ref="tns:priorRemainingDottedAddr"
+  <group name="h_IPAddressGroup">
+    <sequence>
+      <annotation>
+        <appinfo source="http://www.ogf.org/dfdl/">
+          <dfdl:newVariableInstance ref="ipa:priorRemainingDottedAddr"
                                     defaultValue='{ ./value }'/><!-- example 1.2.3.4 -->
-          <dfdl:newVariableInstance ref="tns:remainingDottedAddr"
-                                    defaultValue='{ $tns:priorRemainingDottedAddr }'/><!-- example 1.2.3.4 -->
-        </xs:appinfo>
-      </xs:annotation>
-      <xs:element name="Byte1" type="xs:unsignedByte" dfdl:outputValueCalc="{
-          xs:unsignedByte(fn:substring-before($tns:remainingDottedAddr, '.'))
+          <dfdl:newVariableInstance ref="ipa:remainingDottedAddr"
+                                    defaultValue='{ $ipa:priorRemainingDottedAddr }'/><!-- example 1.2.3.4 -->
+        </appinfo>
+      </annotation>
+      <element name="Byte1" type="xs:unsignedByte" dfdl:outputValueCalc="{
+          xs:unsignedByte(fn:substring-before($ipa:remainingDottedAddr, '.'))
           }"/>
-      <xs:sequence>
-        <xs:annotation>
-          <xs:appinfo source="http://www.ogf.org/dfdl/">
+      <sequence>
+        <annotation>
+          <appinfo source="http://www.ogf.org/dfdl/">
             <dfdl:newVariableInstance
-              ref="tns:priorRemainingDottedAddr"
-              defaultValue='{ $tns:remainingDottedAddr }'/><!-- example 1.2.3.4 -->
+              ref="ipa:priorRemainingDottedAddr"
+              defaultValue='{ $ipa:remainingDottedAddr }'/><!-- example 1.2.3.4 -->
             <dfdl:newVariableInstance
-              ref="tns:remainingDottedAddr"
-              defaultValue='{ fn:substring-after($tns:priorRemainingDottedAddr, ".") }'/><!-- example 2.3.4 -->
-          </xs:appinfo>
-        </xs:annotation>
-        <xs:element name="Byte2" type="xs:unsignedByte" dfdl:outputValueCalc="{
-           xs:unsignedByte(fn:substring-before($tns:remainingDottedAddr, '.'))
+              ref="ipa:remainingDottedAddr"
+              defaultValue='{ fn:substring-after($ipa:priorRemainingDottedAddr, ".") }'/><!-- example 2.3.4 -->
+          </appinfo>
+        </annotation>
+        <element name="Byte2" type="xs:unsignedByte" dfdl:outputValueCalc="{
+           xs:unsignedByte(fn:substring-before($ipa:remainingDottedAddr, '.'))
            }"/>
-        <xs:sequence>
-          <xs:annotation>
-            <xs:appinfo source="http://www.ogf.org/dfdl/">
+        <sequence>
+          <annotation>
+            <appinfo source="http://www.ogf.org/dfdl/">
               <dfdl:newVariableInstance
-                ref="tns:priorRemainingDottedAddr"
-                defaultValue='{ $tns:remainingDottedAddr }'/><!-- example 2.3.4 -->
+                ref="ipa:priorRemainingDottedAddr"
+                defaultValue='{ $ipa:remainingDottedAddr }'/><!-- example 2.3.4 -->
               <dfdl:newVariableInstance
-                ref="tns:remainingDottedAddr"
-                defaultValue='{ fn:substring-after($tns:priorRemainingDottedAddr, ".") }'/><!-- example 3.4 -->
-            </xs:appinfo>
-          </xs:annotation>
-          <xs:element name="Byte3" type="xs:unsignedByte" dfdl:outputValueCalc="{
-              xs:unsignedByte(fn:substring-before($tns:remainingDottedAddr, '.'))
+                ref="ipa:remainingDottedAddr"
+                defaultValue='{ fn:substring-after($ipa:priorRemainingDottedAddr, ".") }'/><!-- example 3.4 -->
+            </appinfo>
+          </annotation>
+          <element name="Byte3" type="xs:unsignedByte" dfdl:outputValueCalc="{
+              xs:unsignedByte(fn:substring-before($ipa:remainingDottedAddr, '.'))
               }"/>
-          <xs:sequence>
-            <xs:annotation>
-              <xs:appinfo source="http://www.ogf.org/dfdl/">
+          <sequence>
+            <annotation>
+              <appinfo source="http://www.ogf.org/dfdl/">
                 <dfdl:newVariableInstance
-                  ref="tns:priorRemainingDottedAddr"
-                  defaultValue='{ $tns:remainingDottedAddr }'/><!-- example 3.4 -->
+                  ref="ipa:priorRemainingDottedAddr"
+                  defaultValue='{ $ipa:remainingDottedAddr }'/><!-- example 3.4 -->
                 <dfdl:newVariableInstance
-                  ref="tns:remainingDottedAddr"
-                  defaultValue='{ fn:substring-after($tns:priorRemainingDottedAddr, ".") }'/><!-- example 4 -->
-              </xs:appinfo>
-            </xs:annotation>
-            <xs:element name="Byte4" type="xs:unsignedByte" dfdl:outputValueCalc="{
-              xs:unsignedByte($tns:remainingDottedAddr)
+                  ref="ipa:remainingDottedAddr"
+                  defaultValue='{ fn:substring-after($ipa:priorRemainingDottedAddr, ".") }'/><!-- example 4 -->
+              </appinfo>
+            </annotation>
+            <element name="Byte4" type="xs:unsignedByte" dfdl:outputValueCalc="{
+              xs:unsignedByte($ipa:remainingDottedAddr)
               }"/>
-          </xs:sequence>
-        </xs:sequence>
-      </xs:sequence>
-    </xs:sequence>
-  </xs:group>
+          </sequence>
+        </sequence>
+      </sequence>
+    </sequence>
+  </group>
 
-</xs:schema>
+</schema>

--- a/src/main/scala/com/owlcyberdefense/dfdl/IPv4ChecksumLayer.scala
+++ b/src/main/scala/com/owlcyberdefense/dfdl/IPv4ChecksumLayer.scala
@@ -36,7 +36,7 @@ import scala.collection.JavaConverters._
  * the data stream it is a processing error.
  */
 final class IPv4ChecksumLayer
-  extends ChecksumLayer("IPv4Checksum", "urn:com.owlcyberdefense.dfdl.IPv4Checksum") {
+  extends ChecksumLayer("IPv4Checksum", "urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4") {
 
   private def layerFixedLengthInBytes = 20
 

--- a/src/test/resources/com/owlcyberdefense/dfdl/testEthernet.tdml
+++ b/src/test/resources/com/owlcyberdefense/dfdl/testEthernet.tdml
@@ -1,40 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tdml:testSuite xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-                xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
-                xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
-                xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-                xmlns:b="urn:basicBinary"
-                xmlns:eth="urn:ethernet"
-                xmlns:ex="http://example.com"
-                defaultRoundTrip="true">
+<testSuite xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+           xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+           xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+           xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
+           xmlns:eth="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
+           xmlns:ex="http://example.com"
+           defaultRoundTrip="true">
 
 
-  <tdml:defineSchema name="s1" elementFormDefault="unqualified">
+  <tdml:defineSchema name="s1" elementFormDefault="unqualified" useDefaultNamespace="false"
+                     xmlns="http://www.w3.org/2001/XMLSchema">
 
-    <xs:import namespace="urn:basicBinary" schemaLocation="/com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd"/>
+    <import namespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb" schemaLocation="/com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd"/>
 
-    <xs:import namespace="urn:ethernet"
+    <import namespace="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
                schemaLocation="/com/owlcyberdefense/dfdl/xsd/ethernetIP.dfdl.xsd"/>
 
-    <dfdl:format ref="b:basicByteBinary"/>
+    <dfdl:format ref="bb:basicByteBinary"/>
 
-    <xs:element name="root">
-      <xs:complexType>
-        <xs:sequence>
-          <xs:element name="Ethernet" type="eth:Ethernet"/>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
+    <element name="root">
+      <complexType>
+        <sequence>
+          <element name="Ethernet" type="eth:Ethernet"/>
+        </sequence>
+      </complexType>
+    </element>
 
-    <xs:element name="array">
-      <xs:complexType>
-        <xs:sequence>
-          <xs:element name="Ethernet" type="eth:Ethernet" minOccurs="1" maxOccurs="unbounded"/>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
+    <element name="array">
+      <complexType>
+        <sequence>
+          <element name="Ethernet" type="eth:Ethernet" minOccurs="1" maxOccurs="unbounded"/>
+        </sequence>
+      </complexType>
+    </element>
 
   </tdml:defineSchema>
 
@@ -42,20 +44,20 @@
   Separate unparser test shows that the IPv4 header is computing the checksum value
   because the infoset starts with 0.
   -->
-  <tdml:unparserTestCase name="icmp1u" root="root" model="s1" roundTrip="none">
-    <tdml:document>
-      <tdml:documentPart type="byte">
+  <unparserTestCase name="icmp1u" root="root" model="s1" roundTrip="none">
+    <document>
+      <documentPart type="byte">
         0050 56e0 1449 000c
         2934 0bde 0800 4500 003c d743 0000 8001
         2b73 c0a8 9e8b ae89 2a4d 0800 2a5c 0200
         2100 6162 6364 6566 6768 696a 6b6c 6d6e
         6f70 7172 7374 7576 7761 6263 6465 6667
         6869
-      </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:root>
+      </documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:root xmlns="">
           <Ethernet>
             <MACDest>005056E01449</MACDest>
             <MACSrc>000C29340BDE</MACSrc>
@@ -93,27 +95,27 @@
             </NetworkLayer>
           </Ethernet>
         </ex:root>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:unparserTestCase>
+      </dfdlInfoset>
+    </infoset>
+  </unparserTestCase>
 
   <!--
   Separate parser test verifies checksum value.
   -->
-  <tdml:parserTestCase name="icmp1" root="root" model="s1" roundTrip="onePass">
-    <tdml:document>
-      <tdml:documentPart type="byte">
+  <parserTestCase name="icmp1" root="root" model="s1" roundTrip="onePass">
+    <document>
+      <documentPart type="byte">
         0050 56e0 1449 000c
         2934 0bde 0800 4500 003c d743 0000 8001
         2b73 c0a8 9e8b ae89 2a4d 0800 2a5c 0200
         2100 6162 6364 6566 6768 696a 6b6c 6d6e
         6f70 7172 7374 7576 7761 6263 6465 6667
         6869
-      </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:root>
+      </documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:root xmlns="">
           <Ethernet>
             <MACDest>005056E01449</MACDest>
             <MACSrc>000C29340BDE</MACSrc>
@@ -151,16 +153,16 @@
             </NetworkLayer>
           </Ethernet>
         </ex:root>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
 
   <!--
 Unparse two IPv4 ICMP packets in a row.
 -->
-  <tdml:unparserTestCase name="icmp_array" root="array" model="s1" roundTrip="none">
-    <tdml:document>
-      <tdml:documentPart type="byte">
+  <unparserTestCase name="icmp_array" root="array" model="s1" roundTrip="none">
+    <document>
+      <documentPart type="byte">
         0050 56e0 1449 000c
         2934 0bde 0800 4500 003c d743 0000 8001
         2b73 c0a8 9e8b ae89 2a4d 0800 2a5c 0200
@@ -173,11 +175,11 @@ Unparse two IPv4 ICMP packets in a row.
         2100 6162 6364 6566 6768 696a 6b6c 6d6e
         6f70 7172 7374 7576 7761 6263 6465 6667
         6869
-      </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:array>
+      </documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:array xmlns="">
           <Ethernet>
             <MACDest>005056E01449</MACDest>
             <MACSrc>000C29340BDE</MACSrc>
@@ -251,30 +253,30 @@ Unparse two IPv4 ICMP packets in a row.
             </NetworkLayer>
           </Ethernet>
         </ex:array>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:unparserTestCase>
+      </dfdlInfoset>
+    </infoset>
+  </unparserTestCase>
 
   <!--
   Separate parser test verifies stored checksum value is incorrect.
 
   Issues runtime warning about incorrect checksum.
   -->
-  <tdml:parserTestCase name="icmp2_bad_checksum" root="root" model="s1" roundTrip="none"
+  <parserTestCase name="icmp2_bad_checksum" root="root" model="s1" roundTrip="none"
     validation="limited">
-    <tdml:document>
-      <tdml:documentPart type="byte">
+    <document>
+      <documentPart type="byte">
         0050 56e0 1449 000c
         2934 0bde 0800 4500 003c d743 2000 8001
         2b73 c0a8 9e8b ae89 2a4d 0800 2a5c 0200
         2100 6162 6364 6566 6768 696a 6b6c 6d6e
         6f70 7172 7374 7576 7761 6263 6465 6667
         6869
-      </tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:root>
+      </documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:root xmlns="">
           <Ethernet>
             <MACDest>005056E01449</MACDest>
             <MACSrc>000C29340BDE</MACSrc>
@@ -312,16 +314,16 @@ Unparse two IPv4 ICMP packets in a row.
             </NetworkLayer>
           </Ethernet>
         </ex:root>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-    <tdml:validationErrors>
-      <tdml:error>Incorrect checksum</tdml:error>
-    </tdml:validationErrors>
-  </tdml:parserTestCase>
+      </dfdlInfoset>
+    </infoset>
+    <validationErrors>
+      <error>Incorrect checksum</error>
+    </validationErrors>
+  </parserTestCase>
 
-  <tdml:parserTestCase name="dns1" root="root" model="s1">
-    <tdml:document>
-      <tdml:documentPart type="byte"><![CDATA[
+  <parserTestCase name="dns1" root="root" model="s1">
+    <document>
+      <documentPart type="byte"><![CDATA[
                                              00
         6008 45e4 5500 12a9 0032 2308 0045 0000
         4500 0040 003a 11f8 a1d9 0d04 18c0 a8aa
@@ -329,11 +331,11 @@ Unparse two IPv4 ICMP packets in a row.
         0000 0000 0005 4752 494d 4d0b 7574 656c
         7379 7374 656d 7305 6c6f 6361 6c00 0001
         0001
-       ]]></tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:root>
+       ]]></documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:root xmlns="">
           <Ethernet>
             <MACDest>00600845E455</MACDest>
             <MACSrc>0012A9003223</MACSrc>
@@ -372,24 +374,24 @@ Unparse two IPv4 ICMP packets in a row.
             </NetworkLayer>
           </Ethernet>
         </ex:root>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
 
 
-  <tdml:parserTestCase name="http_ipv6_1" root="root" model="s1">
-    <tdml:document>
-      <tdml:documentPart type="byte"><![CDATA[
+  <parserTestCase name="http_ipv6_1" root="root" model="s1">
+    <document>
+      <documentPart type="byte"><![CDATA[
             00 1125 8295 b500 d009 e3e8 de86 dd60
           0000 0000 1406 4020 0106 f810 2d00 0002
           d009 fffe e3e8 de20 0106 f809 0007 c000
           0000 0000 0000 02e7 4100 50ab dcd7 5101
           4a7c 7350 112c c037 2300 00
-       ]]></tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:root>
+       ]]></documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:root xmlns="">
           <Ethernet>
             <MACDest>0011258295B5</MACDest>
             <MACSrc>00D009E3E8DE</MACSrc>
@@ -429,13 +431,13 @@ Unparse two IPv4 ICMP packets in a row.
             </NetworkLayer>
           </Ethernet>
         </ex:root>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
 
-  <tdml:parserTestCase name="tcp_ecn_1" root="root" model="s1">
-    <tdml:document>
-      <tdml:documentPart type="byte"><![CDATA[
+  <parserTestCase name="tcp_ecn_1" root="root" model="s1">
+    <document>
+      <documentPart type="byte"><![CDATA[
                                       c0
  0212 6800 00c0 0114 7c00 0108 0045 0300
  b202 3400 00fe 0695 0901 010c 0101 0117
@@ -449,11 +451,11 @@ Unparse two IPv4 ICMP packets in a row.
  6f20 6970 7365 6320 7361 202d 2d2d 2d2d
  2d2d 2d2d 2d2d 2d2d 2d2d 2d2d 2d0a 0a0a
  4e6f 2053 4173 2066 6f75 6e64 0a0a 0a
-       ]]></tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:root>
+       ]]></documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:root xmlns="">
           <Ethernet>
             <MACDest>C00212680000</MACDest>
             <MACSrc>C001147C0001</MACSrc>
@@ -499,9 +501,9 @@ Unparse two IPv4 ICMP packets in a row.
             </NetworkLayer>
           </Ethernet>
         </ex:root>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
 
 
-</tdml:testSuite>
+</testSuite>

--- a/src/test/resources/com/owlcyberdefense/dfdl/testIPAddress.tdml
+++ b/src/test/resources/com/owlcyberdefense/dfdl/testIPAddress.tdml
@@ -1,45 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tdml:testSuite xmlns:xs="http://www.w3.org/2001/XMLSchema"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
-                xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
-                xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
-                xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-                xmlns:b="urn:basicBinary"
-                xmlns:ip="urn:ipAddress"
-                xmlns:ex="http://example.com"
-                defaultRoundTrip="true">
+<testSuite xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+           xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+           xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
+           xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+           xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
+           xmlns:ipa="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa"
+           xmlns:ex="http://example.com"
+           defaultRoundTrip="true">
 
 
-  <tdml:defineSchema name="s1" elementFormDefault="unqualified">
+  <tdml:defineSchema name="s1" elementFormDefault="unqualified" useDefaultNamespace="false"
+                     xmlns="http://www.w3.org/2001/XMLSchema">
 
-    <xs:import namespace="urn:basicBinary" schemaLocation="com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd"/>
+    <import namespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb" schemaLocation="com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd"/>
 
-    <xs:import namespace="urn:ipAddress"
+    <import namespace="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa"
                 schemaLocation="com/owlcyberdefense/dfdl/xsd/ipAddress.dfdl.xsd"/>
 
-    <dfdl:format ref="b:basicByteBinary"/>
+    <dfdl:format ref="bb:basicByteBinary"/>
 
-    <xs:element name="root">
-      <xs:complexType>
-        <xs:sequence>
-          <xs:element name="IP" type="ip:IPAddress"/>
-        </xs:sequence>
-      </xs:complexType>
-    </xs:element>
+    <element name="root">
+      <complexType>
+        <sequence>
+          <element name="IP" type="ipa:IPAddress"/>
+        </sequence>
+      </complexType>
+    </element>
 
   </tdml:defineSchema>
 
-  <tdml:parserTestCase name="ipAddress1" root="root"
+  <parserTestCase name="ipAddress1" root="root"
                        model="s1">
-    <tdml:document>
-      <tdml:documentPart type="byte">01020304</tdml:documentPart>
-    </tdml:document>
-    <tdml:infoset>
-      <tdml:dfdlInfoset>
-        <ex:root><IP><value>1.2.3.4</value></IP></ex:root>
-      </tdml:dfdlInfoset>
-    </tdml:infoset>
-  </tdml:parserTestCase>
+    <document>
+      <documentPart type="byte">01020304</documentPart>
+    </document>
+    <infoset>
+      <dfdlInfoset>
+        <ex:root xmlns="">
+          <IP>
+            <value>1.2.3.4</value>
+          </IP>
+        </ex:root>
+      </dfdlInfoset>
+    </infoset>
+  </parserTestCase>
 
-</tdml:testSuite>
+</testSuite>


### PR DESCRIPTION
Version 1.4.2 Improve Schema Coding Style

Conforms to current (2025-10-17) DFDL schema style guidance. 
Many people use this DFDL schema as part of learning about DFDL, so it 
needed to be updated to reflect known best practices.

This changes many files because many lines, but does not change the shape/structure of the infoset
and there were already no element namespaces so no changes to the XML infosets. 

Version 1.4.1 Update to Daffodil 4.0.0 as default Daffodil

Also updated sbt version to 1.11.6 and
updated README.md

https://github.com/DFDLSchemas/ethernetIP/issues/21