### PR TITLE
Version 1.5.0 Remove excess namespaces. Change PCAP URI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Ethernet, IP, TCP, UDP, ICMP, DNS
 
 DFDL Schemas for Ethernet and IP
 
-It works with Daffodil (from Daffodil version 3.2.0), 
-but not with IBM DFDL (as of 2021-06-08) as the latter does not yet support
+It works with Daffodil (starting from Daffodil version 3.2.0), 
+but not with IBM DFDL (as of 2025-10-21) as the latter does not yet support
 the dfdl:inputValueCalc, dfdl:outputValueCalc, 
 dfdl:hiddenGroupRef, dfdl:valueLength(), dfdl:contentLength(),
 and dfdl:newVariableInstance DFDL capabilities.
@@ -13,13 +13,45 @@ As of version 1.1.0 of this DFDL schema, it also uses a Daffodil-specific DFDL e
 to compute IPv4 checksums as part of parsing and unparsing. 
 
 This schema was created based on the corresponding DFDL types in the PCAP schema, which has been refactored
-to use this schema as a dependency.
+to use this schema as a component dependency.
 
-This division into two schemas is intended to illustrate how to structure DFDL schemas as separate DFDL 
-schemas that are combined together to form a complete format, and which involve layering where a 
-container/envelope/header structure, contains a payload structure. PCAP is an container format for Ethernet/IP packets. 
+This division into two schemas is intended to illustrate how to structure DFDL schemas as 
+separate DFDL component
+schemas that are assembled together to form a complete format, and which involve layering where a 
+container/envelope/header structure, contains a payload structure. PCAP is a container format for Ethernet/IP packets. 
+
+## Usage
+
+The main schema file is `ethernetIP`. It defines the `Ethernet` complex type in the
+target namespace. Assuming version 1.5.0 of this schema, using this type requires this namespace 
+prefix definition:
+
+        xmlns:eth="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
+
+and this import and default format top level annotation:
+
+    <import namespace="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
+               schemaLocation="/com/owlcyberdefense/dfdl/xsd/ethernetIP.dfdl.xsd"/>
+
+    <annotation>
+      <appinfo source="http://www.ogf.org/dfdl/">
+        <dfdl:format ref="eth:basicByteBinary"/> 
+      </appinfo>
+    </annotation>
+
+after which an element can be defined that contains an ethernet packet as:
+
+    <element name="ethernet" type="eth:Ethernet"/>
+
 
 ## Release Notes
+
+### 1.5.0
+
+Namespace URI for PCAP now updated to `urn:owlcyberdefense.com:schema:dfdl:ethernet:eth`,
+following the DFDL Schema Style Guide. 
+
+Other internal namespaces for bb, ipa, removed.
 
 ### 1.4.2
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "dfdl-ethernetIP"
 
 organization := "com.owlcyberdefense"
 
-version := "1.4.2"
+version := "1.5.0"
 
 daffodilVersion := "4.0.0"
 

--- a/src/main/resources/com/owlcyberdefense/dfdl/xsd/IPv4ChecksumLayer.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/dfdl/xsd/IPv4ChecksumLayer.dfdl.xsd
@@ -21,8 +21,8 @@
         xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
         xmlns:fn="http://www.w3.org/2005/xpath-functions"
         xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-        xmlns:ipv4="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4"
-        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4">
+        xmlns:ipv4cs="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4cs"
+        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4cs">
 
   <annotation>
     <documentation>
@@ -37,7 +37,7 @@
     <appinfo source="http://www.ogf.org/dfdl/">
       <dfdl:defineVariable name="IPv4Checksum" type="xs:unsignedShort"/>
       <dfdl:defineFormat name="IPv4ChecksumLayer">
-        <dfdl:format dfdlx:layer='ipv4:IPv4Checksum' />
+        <dfdl:format dfdlx:layer='ipv4cs:IPv4Checksum' />
       </dfdl:defineFormat>
     </appinfo>
   </annotation>

--- a/src/main/resources/com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd
@@ -46,8 +46,8 @@ conventions useful for describing things like IP packets.
         xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
         xmlns:fn="http://www.w3.org/2005/xpath-functions"
         xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-        xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
-        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb">
+        xmlns:eth="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
+        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth">
 
   <include schemaLocation="/org/apache/daffodil/xsd/DFDLGeneralFormat.dfdl.xsd"/>
 
@@ -55,7 +55,7 @@ conventions useful for describing things like IP packets.
     <appinfo source="http://www.ogf.org/dfdl/">
 
       <dfdl:defineFormat name="basicByteBinary">
-        <dfdl:format ref="bb:GeneralFormat"
+        <dfdl:format ref="eth:GeneralFormat"
                      alignment="1"
                      alignmentUnits="bits"
                      binaryBooleanFalseRep="0"
@@ -69,7 +69,7 @@ conventions useful for describing things like IP packets.
                    />
       </dfdl:defineFormat>
 
-      <dfdl:format ref="bb:basicByteBinary"/>
+      <dfdl:format ref="eth:basicByteBinary"/>
 
     </appinfo>
   </annotation>

--- a/src/main/resources/com/owlcyberdefense/dfdl/xsd/ethernetIP.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/dfdl/xsd/ethernetIP.dfdl.xsd
@@ -39,35 +39,27 @@ SOFTWARE.
         xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
         xmlns:fn="http://www.w3.org/2005/xpath-functions"
         xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-        xmlns:chksum="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4"
-        xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
-        xmlns:ipa="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa"
+        xmlns:ipv4cs="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4cs"
         xmlns:eth="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
         targetNamespace="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth">
 
-  <import namespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb" schemaLocation="basicByteBinary.dfdl.xsd"/>
-  <import namespace="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa" schemaLocation="ipAddress.dfdl.xsd"/>
-  <import namespace="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4"
+  <include schemaLocation="basicByteBinary.dfdl.xsd"/>
+  <include schemaLocation="ipAddress.dfdl.xsd"/>
+  <import namespace="urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4cs"
              schemaLocation="IPv4ChecksumLayer.dfdl.xsd"/>
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
 
-      <dfdl:format ref="bb:basicByteBinary"/>
+      <dfdl:format ref="eth:basicByteBinary"/>
 
     </appinfo>
   </annotation>
 
-  <!--
-  This schema does not define any global elements.
-
-  This is because ethernet data is always contained in some other medium such as a PCAP file.
-  -->
-
   <complexType name="Ethernet">
     <sequence>
-      <element name="MACDest" type="bb:hexByte" dfdl:length="6"/>
-      <element name="MACSrc" type="bb:hexByte" dfdl:length="6"/>
-      <element name="Ethertype" type="bb:bit" dfdl:length="16"
+      <element name="MACDest" type="eth:hexByte" dfdl:length="6"/>
+      <element name="MACSrc" type="eth:hexByte" dfdl:length="6"/>
+      <element name="Ethertype" type="eth:bit" dfdl:length="16"
                   dfdl:outputValueCalc="{
           if (fn:exists(../NetworkLayer/IPv4)) then 2048
           else if (fn:exists(../NetworkLayer/IPv6 )) then 34525
@@ -115,17 +107,17 @@ SOFTWARE.
                 it is overwritten (in the layer transform) by the recomputed checksum available for comparison purposes in
                 the ComputedChecksum variable.
                 -->
-                <dfdl:newVariableInstance ref="chksum:IPv4Checksum"/>
+                <dfdl:newVariableInstance ref="ipv4cs:IPv4Checksum"/>
               </appinfo>
             </annotation>
 
-            <sequence dfdl:ref="chksum:IPv4ChecksumLayer">
+            <sequence dfdl:ref="ipv4cs:IPv4ChecksumLayer">
               <sequence>
-                <element name="Version" type="bb:bit" dfdl:length="4"/>
-                <element name="IHL" type="bb:bit" dfdl:length="4"/>
-                <element name="DSCP" type="bb:bit" dfdl:length="6"/>
-                <element name="ECN" type="bb:bit" dfdl:length="2"/>
-                <element name="Length" type="bb:bit" dfdl:length="16"
+                <element name="Version" type="eth:bit" dfdl:length="4"/>
+                <element name="IHL" type="eth:bit" dfdl:length="4"/>
+                <element name="DSCP" type="eth:bit" dfdl:length="6"/>
+                <element name="ECN" type="eth:bit" dfdl:length="2"/>
+                <element name="Length" type="eth:bit" dfdl:length="16"
                             dfdl:outputValueCalc="{
                 if (fn:exists(../../TransportLayer))
                 then
@@ -138,19 +130,19 @@ SOFTWARE.
                      then dfdl:valueLength(../../ICMPv4/EchoRequest/Payload, 'bytes') + 20 + 8
                      else dfdl:valueLength(../../ICMPv4/EchoReply/Payload, 'bytes') + 20 + 8
                 } "/>
-                <element name="Identification" type="bb:bit" dfdl:length="16"/>
-                <element name="Flags" type="bb:bit" dfdl:length="3"/>
-                <element name="FragmentOffset" type="bb:bit" dfdl:length="13"/>
-                <element name="TTL" type="bb:bit" dfdl:length="8"/>
-                <element name="Protocol" type="bb:bit" dfdl:length="8"
+                <element name="Identification" type="eth:bit" dfdl:length="16"/>
+                <element name="Flags" type="eth:bit" dfdl:length="3"/>
+                <element name="FragmentOffset" type="eth:bit" dfdl:length="13"/>
+                <element name="TTL" type="eth:bit" dfdl:length="8"/>
+                <element name="Protocol" type="eth:bit" dfdl:length="8"
                             dfdl:outputValueCalc="{
                 if (fn:exists(../../ICMPv4)) then 1
                 else if (fn:exists(../../TransportLayer/TCP)) then 6
                 else if (fn:exists(../../TransportLayer/UDP)) then 17
                 else -1 }"/>
-                <element name="Checksum" type="chksum:IPv4Checksum"/>
-                <element name="IPSrc" type="ipa:IPAddress"/>
-                <element name="IPDest" type="ipa:IPAddress"/>
+                <element name="Checksum" type="ipv4cs:IPv4Checksum"/>
+                <element name="IPSrc" type="eth:IPAddress"/>
+                <element name="IPDest" type="eth:IPAddress"/>
               </sequence>
             </sequence>
 
@@ -159,8 +151,8 @@ SOFTWARE.
             checksum is incorrect when parsing. Hence, we just put the computed value
             into this element.
             -->
-            <element name="ComputedChecksum" type="chksum:IPv4Checksum"
-                        dfdl:inputValueCalc='{ $chksum:IPv4Checksum }'/>
+            <element name="ComputedChecksum" type="ipv4cs:IPv4Checksum"
+                        dfdl:inputValueCalc='{ $ipv4cs:IPv4Checksum }'/>
             <!--
             One recommendation is to treat incorrect checksum values as a validation
             error. This preserves the ability to use the schema forensically to examine
@@ -203,33 +195,33 @@ SOFTWARE.
 
   <complexType name="ICMPv4">
     <sequence>
-      <element name="Type" type="bb:bit" dfdl:length="8"
+      <element name="Type" type="eth:bit" dfdl:length="8"
                   dfdl:outputValueCalc="{
           if (fn:exists(../EchoRequest)) then 8
           else if (fn:exists(../EchoReply )) then 0
           else -1 }"/>
-      <element name="Code" type="bb:bit" dfdl:length="8"
+      <element name="Code" type="eth:bit" dfdl:length="8"
                   dfdl:outputValueCalc="{
           if (fn:exists(../EchoRequest)) then 0
           else if (fn:exists(../EchoReply )) then 0
           else -1 }"/>
-      <element name="Checksum" type="bb:bit" dfdl:length="16"/>
+      <element name="Checksum" type="eth:bit" dfdl:length="16"/>
       <choice dfdl:choiceDispatchKey="{ fn:concat(xs:string(./Type), '_', xs:string(./Code)) }">
         <element name="EchoRequest" dfdl:choiceBranchKey="8_0">
           <complexType>
             <sequence>
-              <element name="Identifier" type="bb:bit" dfdl:length="16"/>
-              <element name="SequenceNumber" type="bb:bit" dfdl:length="16"/>
-              <element name="Payload" type="bb:hexByte" dfdl:length="{ (../../../IPv4Header/Length - 20) - 8 }"/>
+              <element name="Identifier" type="eth:bit" dfdl:length="16"/>
+              <element name="SequenceNumber" type="eth:bit" dfdl:length="16"/>
+              <element name="Payload" type="eth:hexByte" dfdl:length="{ (../../../IPv4Header/Length - 20) - 8 }"/>
             </sequence>
           </complexType>
         </element>
         <element name="EchoReply" dfdl:choiceBranchKey="0_0">
           <complexType>
             <sequence>
-              <element name="Identifier" type="bb:bit" dfdl:length="16"/>
-              <element name="SequenceNumber" type="bb:bit" dfdl:length="16"/>
-              <element name="Payload" type="bb:hexByte" dfdl:length="{ (../../../IPv4Header/Length - 20) - 8 }"/>
+              <element name="Identifier" type="eth:bit" dfdl:length="16"/>
+              <element name="SequenceNumber" type="eth:bit" dfdl:length="16"/>
+              <element name="Payload" type="eth:hexByte" dfdl:length="{ (../../../IPv4Header/Length - 20) - 8 }"/>
             </sequence>
           </complexType>
         </element>
@@ -242,10 +234,10 @@ SOFTWARE.
       <element name='IPv6Header'>
         <complexType>
           <sequence>
-            <element name="Version" type="bb:bit" dfdl:length="4"/>
-            <element name="TrafficClass" type="bb:bit" dfdl:length="8"/>
-            <element name="FlowLabel" type="bb:bit" dfdl:length="20"/>
-            <element name="PayloadLength" type="bb:bit" dfdl:length="16"
+            <element name="Version" type="eth:bit" dfdl:length="4"/>
+            <element name="TrafficClass" type="eth:bit" dfdl:length="8"/>
+            <element name="FlowLabel" type="eth:bit" dfdl:length="20"/>
+            <element name="PayloadLength" type="eth:bit" dfdl:length="16"
                         dfdl:outputValueCalc="{
                   if (fn:exists(../../TransportLayer/UDP))
                     then dfdl:valueLength(../../TransportLayer/UDP/Data, 'bytes') + 8
@@ -253,23 +245,23 @@ SOFTWARE.
                          dfdl:valueLength(../../TransportLayer/TCP/TCPHeader/Options, 'bytes') + 20
                 } "/>
             <!-- TODO: Add support for extension headers -->
-            <element name="NextHeader" type="bb:bit" dfdl:length="8"
+            <element name="NextHeader" type="eth:bit" dfdl:length="8"
                         dfdl:outputValueCalc="{
                   if (fn:exists(../../TransportLayer/TCP )) then 6
                   else if (fn:exists(../../TransportLayer/UDP )) then 17
                   else -1 }"/>
-            <element name="HopLimit" type="bb:bit" dfdl:length="8"/>
+            <element name="HopLimit" type="eth:bit" dfdl:length="8"/>
             <element name="IPSrc">
               <complexType>
                 <sequence>
-                  <element name="value" type="bb:hexByte" dfdl:length="16"/>
+                  <element name="value" type="eth:hexByte" dfdl:length="16"/>
                 </sequence>
               </complexType>
             </element>
             <element name="IPDest">
               <complexType>
                 <sequence>
-                  <element name="value" type="bb:hexByte" dfdl:length="16"/>
+                  <element name="value" type="eth:hexByte" dfdl:length="16"/>
                 </sequence>
               </complexType>
             </element>
@@ -297,22 +289,22 @@ SOFTWARE.
       <element name='TCPHeader'>
         <complexType>
           <sequence>
-            <element name="PortSRC" type="bb:bit" dfdl:length="16"/>
-            <element name="PortDest" type="bb:bit" dfdl:length="16"/>
-            <element name="Seq" type="bb:bit" dfdl:length="32"/>
-            <element name="Ack" type="bb:bit" dfdl:length="32"/>
-            <element name="DataOffset" type="bb:bit" dfdl:length="4"
+            <element name="PortSRC" type="eth:bit" dfdl:length="16"/>
+            <element name="PortDest" type="eth:bit" dfdl:length="16"/>
+            <element name="Seq" type="eth:bit" dfdl:length="32"/>
+            <element name="Ack" type="eth:bit" dfdl:length="32"/>
+            <element name="DataOffset" type="eth:bit" dfdl:length="4"
                         dfdl:outputValueCalc="{ xs:unsignedInt((dfdl:valueLength(../Options, 'bytes') div 4) + 5) }"/>
-            <element name="Reserved" type="bb:bit" dfdl:length="3"/>
-            <element name="Flags" type="bb:bit" dfdl:length="9"/>
-            <element name="WindowSize" type="bb:bit" dfdl:length="16"/>
-            <element name="Checksum" type="bb:bit" dfdl:length="16"/>
-            <element name="Urgent" type="bb:bit" dfdl:length="16"/>
-            <element name="Options" type="bb:hexByte" dfdl:length="{ (xs:unsignedInt(../DataOffset) - 5) * 4 }"/>
+            <element name="Reserved" type="eth:bit" dfdl:length="3"/>
+            <element name="Flags" type="eth:bit" dfdl:length="9"/>
+            <element name="WindowSize" type="eth:bit" dfdl:length="16"/>
+            <element name="Checksum" type="eth:bit" dfdl:length="16"/>
+            <element name="Urgent" type="eth:bit" dfdl:length="16"/>
+            <element name="Options" type="eth:hexByte" dfdl:length="{ (xs:unsignedInt(../DataOffset) - 5) * 4 }"/>
           </sequence>
         </complexType>
       </element>
-      <element name="Data" type="bb:hexByte" dfdl:length="{
+      <element name="Data" type="eth:hexByte" dfdl:length="{
           if (fn:exists(../../../../IPv4))
           then ((xs:unsignedInt(../../../../IPv4/IPv4Header/Length) - 20) - (xs:unsignedInt(../TCPHeader/DataOffset) * 4))
           else (xs:unsignedInt(../../../../IPv6/IPv6Header/PayloadLength) - (xs:unsignedInt(../TCPHeader/DataOffset) * 4)) }"/>
@@ -324,15 +316,15 @@ SOFTWARE.
       <element name='UDPHeader'>
         <complexType>
           <sequence>
-            <element name="PortSrc" type="bb:bit" dfdl:length="16"/>
-            <element name="PortDest" type="bb:bit" dfdl:length="16"/>
-            <element name="Length" type="bb:bit" dfdl:length="16"
+            <element name="PortSrc" type="eth:bit" dfdl:length="16"/>
+            <element name="PortDest" type="eth:bit" dfdl:length="16"/>
+            <element name="Length" type="eth:bit" dfdl:length="16"
                         dfdl:outputValueCalc="{ dfdl:valueLength(../../Data, 'bytes') + 8 }"/>
-            <element name="Checksum" type="bb:bit" dfdl:length="16"/>
+            <element name="Checksum" type="eth:bit" dfdl:length="16"/>
           </sequence>
         </complexType>
       </element>
-      <element name="Data" type="bb:hexByte" dfdl:length="{ xs:unsignedInt(../UDPHeader/Length) - 8 }"/>
+      <element name="Data" type="eth:hexByte" dfdl:length="{ xs:unsignedInt(../UDPHeader/Length) - 8 }"/>
     </sequence>
   </complexType>
 

--- a/src/main/resources/com/owlcyberdefense/dfdl/xsd/ipAddress.dfdl.xsd
+++ b/src/main/resources/com/owlcyberdefense/dfdl/xsd/ipAddress.dfdl.xsd
@@ -39,16 +39,15 @@ SOFTWARE.
         xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
         xmlns:fn="http://www.w3.org/2005/xpath-functions"
         xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-        xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
-        xmlns:ipa="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa"
-        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa">
+        xmlns:eth="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
+        targetNamespace="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth">
 
-  <import namespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb" schemaLocation="basicByteBinary.dfdl.xsd"/>
+  <include schemaLocation="basicByteBinary.dfdl.xsd"/>
 
   <annotation>
     <appinfo source="http://www.ogf.org/dfdl/">
 
-      <dfdl:format ref="bb:basicByteBinary"/>
+      <dfdl:format ref="eth:basicByteBinary"/>
 
     </appinfo>
   </annotation>
@@ -89,7 +88,7 @@ SOFTWARE.
       ]]></documentation>
     </annotation>
     <sequence>
-      <sequence dfdl:hiddenGroupRef="ipa:h_IPAddressGroup"/>
+      <sequence dfdl:hiddenGroupRef="eth:h_IPAddressGroup"/>
       <element name="value" type="xs:string"
                   dfdl:inputValueCalc="{ fn:concat(../Byte1, '.', ../Byte2, '.', ../Byte3, '.', ../Byte4) }"/>
     </sequence>
@@ -109,56 +108,56 @@ SOFTWARE.
     <sequence>
       <annotation>
         <appinfo source="http://www.ogf.org/dfdl/">
-          <dfdl:newVariableInstance ref="ipa:priorRemainingDottedAddr"
+          <dfdl:newVariableInstance ref="eth:priorRemainingDottedAddr"
                                     defaultValue='{ ./value }'/><!-- example 1.2.3.4 -->
-          <dfdl:newVariableInstance ref="ipa:remainingDottedAddr"
-                                    defaultValue='{ $ipa:priorRemainingDottedAddr }'/><!-- example 1.2.3.4 -->
+          <dfdl:newVariableInstance ref="eth:remainingDottedAddr"
+                                    defaultValue='{ $eth:priorRemainingDottedAddr }'/><!-- example 1.2.3.4 -->
         </appinfo>
       </annotation>
       <element name="Byte1" type="xs:unsignedByte" dfdl:outputValueCalc="{
-          xs:unsignedByte(fn:substring-before($ipa:remainingDottedAddr, '.'))
+          xs:unsignedByte(fn:substring-before($eth:remainingDottedAddr, '.'))
           }"/>
       <sequence>
         <annotation>
           <appinfo source="http://www.ogf.org/dfdl/">
             <dfdl:newVariableInstance
-              ref="ipa:priorRemainingDottedAddr"
-              defaultValue='{ $ipa:remainingDottedAddr }'/><!-- example 1.2.3.4 -->
+              ref="eth:priorRemainingDottedAddr"
+              defaultValue='{ $eth:remainingDottedAddr }'/><!-- example 1.2.3.4 -->
             <dfdl:newVariableInstance
-              ref="ipa:remainingDottedAddr"
-              defaultValue='{ fn:substring-after($ipa:priorRemainingDottedAddr, ".") }'/><!-- example 2.3.4 -->
+              ref="eth:remainingDottedAddr"
+              defaultValue='{ fn:substring-after($eth:priorRemainingDottedAddr, ".") }'/><!-- example 2.3.4 -->
           </appinfo>
         </annotation>
         <element name="Byte2" type="xs:unsignedByte" dfdl:outputValueCalc="{
-           xs:unsignedByte(fn:substring-before($ipa:remainingDottedAddr, '.'))
+           xs:unsignedByte(fn:substring-before($eth:remainingDottedAddr, '.'))
            }"/>
         <sequence>
           <annotation>
             <appinfo source="http://www.ogf.org/dfdl/">
               <dfdl:newVariableInstance
-                ref="ipa:priorRemainingDottedAddr"
-                defaultValue='{ $ipa:remainingDottedAddr }'/><!-- example 2.3.4 -->
+                ref="eth:priorRemainingDottedAddr"
+                defaultValue='{ $eth:remainingDottedAddr }'/><!-- example 2.3.4 -->
               <dfdl:newVariableInstance
-                ref="ipa:remainingDottedAddr"
-                defaultValue='{ fn:substring-after($ipa:priorRemainingDottedAddr, ".") }'/><!-- example 3.4 -->
+                ref="eth:remainingDottedAddr"
+                defaultValue='{ fn:substring-after($eth:priorRemainingDottedAddr, ".") }'/><!-- example 3.4 -->
             </appinfo>
           </annotation>
           <element name="Byte3" type="xs:unsignedByte" dfdl:outputValueCalc="{
-              xs:unsignedByte(fn:substring-before($ipa:remainingDottedAddr, '.'))
+              xs:unsignedByte(fn:substring-before($eth:remainingDottedAddr, '.'))
               }"/>
           <sequence>
             <annotation>
               <appinfo source="http://www.ogf.org/dfdl/">
                 <dfdl:newVariableInstance
-                  ref="ipa:priorRemainingDottedAddr"
-                  defaultValue='{ $ipa:remainingDottedAddr }'/><!-- example 3.4 -->
+                  ref="eth:priorRemainingDottedAddr"
+                  defaultValue='{ $eth:remainingDottedAddr }'/><!-- example 3.4 -->
                 <dfdl:newVariableInstance
-                  ref="ipa:remainingDottedAddr"
-                  defaultValue='{ fn:substring-after($ipa:priorRemainingDottedAddr, ".") }'/><!-- example 4 -->
+                  ref="eth:remainingDottedAddr"
+                  defaultValue='{ fn:substring-after($eth:priorRemainingDottedAddr, ".") }'/><!-- example 4 -->
               </appinfo>
             </annotation>
             <element name="Byte4" type="xs:unsignedByte" dfdl:outputValueCalc="{
-              xs:unsignedByte($ipa:remainingDottedAddr)
+              xs:unsignedByte($eth:remainingDottedAddr)
               }"/>
           </sequence>
         </sequence>

--- a/src/main/scala/com/owlcyberdefense/dfdl/IPv4ChecksumLayer.scala
+++ b/src/main/scala/com/owlcyberdefense/dfdl/IPv4ChecksumLayer.scala
@@ -36,7 +36,7 @@ import scala.collection.JavaConverters._
  * the data stream it is a processing error.
  */
 final class IPv4ChecksumLayer
-  extends ChecksumLayer("IPv4Checksum", "urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4") {
+  extends ChecksumLayer("IPv4Checksum", "urn:owlcyberdefense.com:schema:dfdl:IPv4Checksum:ipv4cs") {
 
   private def layerFixedLengthInBytes = 20
 

--- a/src/test/resources/com/owlcyberdefense/dfdl/testEthernet.tdml
+++ b/src/test/resources/com/owlcyberdefense/dfdl/testEthernet.tdml
@@ -6,7 +6,6 @@
            xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
            xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
            xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-           xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
            xmlns:eth="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
            xmlns:ex="http://example.com"
            defaultRoundTrip="true">
@@ -15,12 +14,10 @@
   <tdml:defineSchema name="s1" elementFormDefault="unqualified" useDefaultNamespace="false"
                      xmlns="http://www.w3.org/2001/XMLSchema">
 
-    <import namespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb" schemaLocation="/com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd"/>
-
     <import namespace="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
                schemaLocation="/com/owlcyberdefense/dfdl/xsd/ethernetIP.dfdl.xsd"/>
 
-    <dfdl:format ref="bb:basicByteBinary"/>
+    <dfdl:format ref="eth:basicByteBinary"/>
 
     <element name="root">
       <complexType>

--- a/src/test/resources/com/owlcyberdefense/dfdl/testIPAddress.tdml
+++ b/src/test/resources/com/owlcyberdefense/dfdl/testIPAddress.tdml
@@ -6,8 +6,7 @@
            xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
            xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
            xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
-           xmlns:bb="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb"
-           xmlns:ipa="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa"
+           xmlns:eth="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
            xmlns:ex="http://example.com"
            defaultRoundTrip="true">
 
@@ -15,17 +14,15 @@
   <tdml:defineSchema name="s1" elementFormDefault="unqualified" useDefaultNamespace="false"
                      xmlns="http://www.w3.org/2001/XMLSchema">
 
-    <import namespace="urn:owlcyberdefense.com:schema:dfdl:basicBinary:bb" schemaLocation="com/owlcyberdefense/dfdl/xsd/basicByteBinary.dfdl.xsd"/>
+    <import namespace="urn:owlcyberdefense.com:schema:dfdl:ethernet:eth"
+            schemaLocation="/com/owlcyberdefense/dfdl/xsd/ethernetIP.dfdl.xsd"/>
 
-    <import namespace="urn:owlcyberdefense.com:schema:dfdl:ipAddress:ipa"
-                schemaLocation="com/owlcyberdefense/dfdl/xsd/ipAddress.dfdl.xsd"/>
-
-    <dfdl:format ref="bb:basicByteBinary"/>
+    <dfdl:format ref="eth:basicByteBinary"/>
 
     <element name="root">
       <complexType>
         <sequence>
-          <element name="IP" type="ipa:IPAddress"/>
+          <element name="IP" type="eth:IPAddress"/>
         </sequence>
       </complexType>
     </element>


### PR DESCRIPTION
namespace URI now follows conventions.

Eliminate the bb, ipa namespaces.
Retain the one for the layer, but the rest
are not needed.

Principle here is that one schema should usually mean one namespace to understand for all its formats, types, and groups to
be defined in.
We make an exception for layer definitions.

Update README.md with usage instructions.

https://github.com/DFDLSchemas/ethernetIP/issues/21